### PR TITLE
First docker devcontainer is running

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,174 @@
+#FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
+# Another option would be use the offical image from ubuntu, # Use the official Ubuntu base image
+FROM ubuntu:latest
+
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="ubuntu-24.04"
+
+# Set environment variables (optional but good practice)
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update the Ubuntu package list and install necessary packages
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y \
+    build-essential \
+    ca-certificates \
+    ccache \
+    cmake \
+    coreutils \
+    cppcheck \
+    curl \
+    debianutils \
+    dialog \
+    diffutils \
+    dirmngr \
+    dpkg \
+    e2fsprogs \
+    gcc-12 \
+    g++-12 \
+    git \
+    git-man \
+    gnupg \
+    gnupg-l10n \
+    gnupg-utils \
+    gnupg2 \
+    gpg \
+    gpg-agent \
+    gpg-wks-client \
+    gpg-wks-server \
+    gpgconf \
+    gpgsm \
+    gpgv \
+    groff-base \
+    gzip \
+    htop \
+    iproute2 \
+    jq \
+    locales \
+    login \
+    lsof \
+    media-types \
+    mount \
+    mold \
+    nano \
+    ninja-build \
+    ncdu \
+    netbase \
+    openssh-client \
+    openssl \
+    passwd \
+    psmisc \
+    python3 \
+    python3-minimal \
+    readline-common \
+    rsync \
+    sed \
+    strace \
+    sudo \
+    sqlite3 \
+    sysvinit-utils \
+    tar \
+    tzdata \
+    unzip \
+    util-linux \
+    vim-common \
+    vim-tiny \
+    wget \
+    xxd \
+    zip \
+    zlib1g  \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# # 1. Install GCC 14.x (build from source as it's not available through apt)
+# RUN cd /tmp && \
+#     wget https://ftp.gnu.org/gnu/gcc/gcc-14.1.0/gcc-14.1.0.tar.gz && \
+#     tar -xzf gcc-14.1.0.tar.gz && cd gcc-14.1.0 && \
+#     ./contrib/download_prerequisites && \
+#     mkdir build && cd build && \
+#     ../configure --enable-languages=c,c++ --disable-multilib && \
+#     make -j$(nproc) && \
+#     make install
+
+# # 3. Install CMake >= 3.28
+# RUN apt-get remove cmake && \
+#     cd /tmp && \
+#     wget https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0.tar.gz && \
+#     tar -xzvf cmake-3.28.0.tar.gz && cd cmake-3.28.0 && \
+#     ./bootstrap && \
+#     make -j$(nproc) && \
+#     make install
+
+# # 4. Install MoLD >= 2.30
+# RUN apt-get remove -y mold && \
+#     cd /tmp && \
+#     wget https://github.com/rui314/mold/releases/download/v2.30/mold-2.30.tar.gz && \
+#     tar -xzvf mold-2.30.tar.gz && cd mold-2.30 && \
+#     make -j$(nproc) && \
+#     make install
+
+# # 5. Install CCache >= 4.9.1
+# RUN apt-get remove -y ccache && \
+#     cd /tmp && \
+#     wget https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1.tar.gz && \
+#     tar -xzvf ccache-4.9.1.tar.gz && cd ccache-4.9.1 && \
+#     ./configure && \
+#     make -j$(nproc) && \
+#     make install
+
+# # 6. Install Doxygen >= 1.9.8
+# RUN apt-get remove -y doxygen && \
+#     cd /tmp && \
+#     wget https://github.com/doxygen/doxygen/archive/refs/tags/Release_1_9_8.tar.gz && \
+#     tar -xzf Release_1_9_8.tar.gz && cd doxygen-Release_1_9_8 && \
+#     cmake -Bbuild -H. && \
+#     cmake --build build && \
+#     cmake --install build
+
+# # 7. Install Vcpkg (newest)
+# RUN git clone https://github.com/microsoft/vcpkg.git /usr/local/vcpkg && \
+#     /usr/local/vcpkg/bootstrap-vcpkg.sh
+
+# # 8. Install cppCheck >= 2.13
+# RUN apt-get remove -y cppcheck && \
+#     cd /tmp && \
+#     wget https://github.com/danmar/cppcheck/archive/refs/tags/2.13.tar.gz && \
+#     tar -xzvf 2.13.tar.gz && cd cppcheck-2.13 && \
+#     cmake -Bbuild -H. && \
+#     cmake --build build && \
+#     cmake --install build
+
+# # 9. Install SQLite >= 3.44
+# RUN apt-get remove sqlite3 && \
+#     cd /tmp && \
+#     wget https://www.sqlite.org/2023/sqlite-autoconf-3440000.tar.gz && \
+#     tar -xvzf sqlite-autoconf-3440000.tar.gz && \
+#     cd sqlite-autoconf-3440000 && \
+#     ./configure && \
+#     make -j$(nproc) && \
+#     make install
+
+# # 10. Set GCC 14 as the default GCC compiler
+# RUN update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc-14.1.0 60 && \
+#     update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++-14.1.0 60
+
+# # Clean up
+# RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Set timezone (optional)
+RUN ln -fs /usr/share/zoneinfo/Europe/Zurich /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
+
+# Create a user with sudo privileges (optional)
+RUN useradd -ms /bin/bash dockeruser && echo "dockeruser:password" | chpasswd && adduser dockeruser sudo
+
+# Set the default user (optional)
+USER dockeruser
+
+# Set the default working directory
+WORKDIR /home/dockeruser
+
+# Expose port 22 for SSH (if needed)
+EXPOSE 22
+
+# Entry point (optional, depends on use case)
+CMD [ "bash" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,11 +49,9 @@ RUN apt-get update && apt-get upgrade -y && \
     iproute2 \
     jq \
     libtool \
-    # libicu74 \
     icu-devtools \
     libpng-dev \
-    # libzip \
-    # liblzma \
+    libzip-dev \
     locales \
     login \
     lua5.4\
@@ -78,6 +76,7 @@ RUN apt-get update && apt-get upgrade -y && \
     sudo \
     sysvinit-utils \
     sqlite3 \
+    sqlite3-tools \
     tar \
     tzdata \
     unzip \
@@ -87,76 +86,8 @@ RUN apt-get update && apt-get upgrade -y && \
     wget \
     xxd \
     zip \
-    zlib1g  \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-
-# # # 1. Install GCC 14.x (build from source as it's not available through apt)
-# RUN cd /tmp && \
-#     wget https://ftp.gnu.org/gnu/gcc/gcc-14.1.0/gcc-14.1.0.tar.gz && \
-#     tar -xzf gcc-14.1.0.tar.gz && cd gcc-14.1.0 && \
-#     ./contrib/download_prerequisites && \
-#     mkdir build && cd build && \
-#     ../configure --enable-languages=c,c++ --disable-multilib && \
-#     make -j$(nproc) && \
-#     make install
-
-# # 3. Install CMake >= 3.28
-# RUN cd /tmp && \
-#     wget https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0.tar.gz && \
-#     tar -xzvf cmake-3.28.0.tar.gz && cd cmake-3.28.0 && \
-#     ./bootstrap && \
-#     make -j$(nproc) && \
-#     make install
-
-# # # 4. Install MoLD >= 2.30
-# RUN cd /tmp && \
-#     wget https://github.com/rui314/mold/releases/download/v2.30/mold-2.30.tar.gz && \
-#     tar -xzvf mold-2.30.tar.gz && cd mold-2.30 && \
-#     make -j$(nproc) && \
-#     make install
-
-# # # 5. Install CCache >= 4.9.1
-# RUN cd /tmp && \
-#     wget https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1.tar.gz && \
-#     tar -xzvf ccache-4.9.1.tar.gz && cd ccache-4.9.1 && \
-#     ./configure && \
-#     make -j$(nproc) && \
-#     make install
-
-# # # 6. Install Doxygen >= 1.9.8
-# RUN cd /tmp && \
-#     wget https://github.com/doxygen/doxygen/archive/refs/tags/Release_1_9_8.tar.gz && \
-#     tar -xzf Release_1_9_8.tar.gz && cd doxygen-Release_1_9_8 && \
-#     cmake -Bbuild -H. && \
-#     cmake --build build && \
-#     cmake --install build
-
-# # # 7. Install Vcpkg (newest)
-# # RUN git clone https://github.com/microsoft/vcpkg.git /usr/local/vcpkg && \
-# #     /usr/local/vcpkg/bootstrap-vcpkg.sh
-
-# # 8. Install cppCheck >= 2.13
-# RUN cd /tmp && \
-#     wget https://github.com/danmar/cppcheck/archive/refs/tags/2.13.tar.gz && \
-#     tar -xzvf 2.13.tar.gz && cd cppcheck-2.13 && \
-#     cmake -Bbuild -H. && \
-#     cmake --build build && \
-#     cmake --install build
-
-# # # 9. Install SQLite >= 3.44
-# RUN cd /tmp && \
-#     wget https://www.sqlite.org/2023/sqlite-autoconf-3440000.tar.gz && \
-#     tar -xvzf sqlite-autoconf-3440000.tar.gz && \
-#     cd sqlite-autoconf-3440000 && \
-#     ./configure && \
-#     make -j$(nproc) && \
-#     make install
-
-# # # 10. Set GCC 14 as the default GCC compiler
-#  RUN update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc-14.1.0 60 && \
-#      update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++-14.1.0 60
 
 # # Clean up
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
 # Another option would be use the offical image from ubuntu, # Use the official Ubuntu base image
-# FROM ubuntu:latest
+#FROM ubuntu:latest
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="ubuntu-24.04"
 
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get upgrade -y && \
     htop \
     iproute2 \
     jq \
+    libtool \
     # libicu74 \
     icu-devtools \
     libpng-dev \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-#FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
 # Another option would be use the offical image from ubuntu, # Use the official Ubuntu base image
-FROM ubuntu:latest
+# FROM ubuntu:latest
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="ubuntu-24.04"
 
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get upgrade -y && \
     strace \
     sudo \
     sysvinit-utils \
-    sqlite \
+    sqlite3 \
     tar \
     tzdata \
     unzip \
@@ -99,7 +99,7 @@ RUN apt-get update && apt-get upgrade -y && \
 #     make -j$(nproc) && \
 #     make install
 
-# # # 3. Install CMake >= 3.28
+# # 3. Install CMake >= 3.28
 # RUN cd /tmp && \
 #     wget https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0.tar.gz && \
 #     tar -xzvf cmake-3.28.0.tar.gz && cd cmake-3.28.0 && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,21 +10,24 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Update the Ubuntu package list and install necessary packages
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
+    autoconf \
+    automake \
+    autoconf-archive \
     build-essential \
     ca-certificates \
-    ccache \
-    cmake \
     coreutils \
+    bash \
+    cmake \
+    ccache \
     cppcheck \
     curl \
     debianutils \
     dialog \
     diffutils \
     dirmngr \
+    doxygen \
     dpkg \
     e2fsprogs \
-    gcc-12 \
-    g++-12 \
     git \
     git-man \
     gnupg \
@@ -43,8 +46,14 @@ RUN apt-get update && apt-get upgrade -y && \
     htop \
     iproute2 \
     jq \
+    # libicu74 \
+    icu-devtools \
+    libpng-dev \
+    # libzip \
+    # liblzma \
     locales \
     login \
+    lua5.4\
     lsof \
     media-types \
     mount \
@@ -64,8 +73,8 @@ RUN apt-get update && apt-get upgrade -y && \
     sed \
     strace \
     sudo \
-    sqlite3 \
     sysvinit-utils \
+    sqlite \
     tar \
     tzdata \
     unzip \
@@ -80,7 +89,7 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 
 
-# # 1. Install GCC 14.x (build from source as it's not available through apt)
+# # # 1. Install GCC 14.x (build from source as it's not available through apt)
 # RUN cd /tmp && \
 #     wget https://ftp.gnu.org/gnu/gcc/gcc-14.1.0/gcc-14.1.0.tar.gz && \
 #     tar -xzf gcc-14.1.0.tar.gz && cd gcc-14.1.0 && \
@@ -90,57 +99,51 @@ RUN apt-get update && apt-get upgrade -y && \
 #     make -j$(nproc) && \
 #     make install
 
-# # 3. Install CMake >= 3.28
-# RUN apt-get remove cmake && \
-#     cd /tmp && \
+# # # 3. Install CMake >= 3.28
+# RUN cd /tmp && \
 #     wget https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0.tar.gz && \
 #     tar -xzvf cmake-3.28.0.tar.gz && cd cmake-3.28.0 && \
 #     ./bootstrap && \
 #     make -j$(nproc) && \
 #     make install
 
-# # 4. Install MoLD >= 2.30
-# RUN apt-get remove -y mold && \
-#     cd /tmp && \
+# # # 4. Install MoLD >= 2.30
+# RUN cd /tmp && \
 #     wget https://github.com/rui314/mold/releases/download/v2.30/mold-2.30.tar.gz && \
 #     tar -xzvf mold-2.30.tar.gz && cd mold-2.30 && \
 #     make -j$(nproc) && \
 #     make install
 
-# # 5. Install CCache >= 4.9.1
-# RUN apt-get remove -y ccache && \
-#     cd /tmp && \
+# # # 5. Install CCache >= 4.9.1
+# RUN cd /tmp && \
 #     wget https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1.tar.gz && \
 #     tar -xzvf ccache-4.9.1.tar.gz && cd ccache-4.9.1 && \
 #     ./configure && \
 #     make -j$(nproc) && \
 #     make install
 
-# # 6. Install Doxygen >= 1.9.8
-# RUN apt-get remove -y doxygen && \
-#     cd /tmp && \
+# # # 6. Install Doxygen >= 1.9.8
+# RUN cd /tmp && \
 #     wget https://github.com/doxygen/doxygen/archive/refs/tags/Release_1_9_8.tar.gz && \
 #     tar -xzf Release_1_9_8.tar.gz && cd doxygen-Release_1_9_8 && \
 #     cmake -Bbuild -H. && \
 #     cmake --build build && \
 #     cmake --install build
 
-# # 7. Install Vcpkg (newest)
-# RUN git clone https://github.com/microsoft/vcpkg.git /usr/local/vcpkg && \
-#     /usr/local/vcpkg/bootstrap-vcpkg.sh
+# # # 7. Install Vcpkg (newest)
+# # RUN git clone https://github.com/microsoft/vcpkg.git /usr/local/vcpkg && \
+# #     /usr/local/vcpkg/bootstrap-vcpkg.sh
 
 # # 8. Install cppCheck >= 2.13
-# RUN apt-get remove -y cppcheck && \
-#     cd /tmp && \
+# RUN cd /tmp && \
 #     wget https://github.com/danmar/cppcheck/archive/refs/tags/2.13.tar.gz && \
 #     tar -xzvf 2.13.tar.gz && cd cppcheck-2.13 && \
 #     cmake -Bbuild -H. && \
 #     cmake --build build && \
 #     cmake --install build
 
-# # 9. Install SQLite >= 3.44
-# RUN apt-get remove sqlite3 && \
-#     cd /tmp && \
+# # # 9. Install SQLite >= 3.44
+# RUN cd /tmp && \
 #     wget https://www.sqlite.org/2023/sqlite-autoconf-3440000.tar.gz && \
 #     tar -xvzf sqlite-autoconf-3440000.tar.gz && \
 #     cd sqlite-autoconf-3440000 && \
@@ -148,12 +151,12 @@ RUN apt-get update && apt-get upgrade -y && \
 #     make -j$(nproc) && \
 #     make install
 
-# # 10. Set GCC 14 as the default GCC compiler
-# RUN update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc-14.1.0 60 && \
-#     update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++-14.1.0 60
+# # # 10. Set GCC 14 as the default GCC compiler
+#  RUN update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc-14.1.0 60 && \
+#      update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++-14.1.0 60
 
 # # Clean up
-# RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Set timezone (optional)
 RUN ln -fs /usr/share/zoneinfo/Europe/Zurich /etc/localtime && dpkg-reconfigure -f noninteractive tzdata

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,8 @@ ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="ubuntu-24.04"
 
 # Set environment variables (optional but good practice)
 ENV DEBIAN_FRONTEND=noninteractive
+# This env is for it to work on mac
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 
 # Update the Ubuntu package list and install necessary packages
 RUN apt-get update && apt-get upgrade -y && \

--- a/.devcontainer/devcontainer-list_20240927.md
+++ b/.devcontainer/devcontainer-list_20240927.md
@@ -1,6 +1,8 @@
 Tools needed to dev and build WorkHorz (mandatory)
 
-    Ubuntu OS >= 24.04 (soon 24.10)
+## Oct 16th Version
+
+Ubuntu OS >= 24.04 (soon 24.10)
     GCC >= 14.1 (soon 14.2)
     Standard: C++23 (soon C++26)
     MoLD >= 2.30 (linker)
@@ -18,3 +20,17 @@ Tools needed to dev and build WorkHorz (mandatory)
 Installing newer version of GCC on Ubunutu
 
     Explained here: https://www.dedicatedcore.com/blog/install-gcc-compiler-ubuntu/ 
+
+Autoconf tools:
+      autoconf >= 2.71
+      automake >= 1.16.5
+      autoconf-archive >= 20220903-3
+Autotools
+ICU:
+  libicu74 >= 74.2
+  icu-devtools
+libtool (for libsodium at least)
+PNG: libpng-dev
+libzip
+liblzma
+

--- a/.devcontainer/devcontainer-list_20240927.txt
+++ b/.devcontainer/devcontainer-list_20240927.txt
@@ -1,0 +1,20 @@
+Tools needed to dev and build WorkHorz (mandatory)
+
+    Ubuntu OS >= 24.04 (soon 24.10)
+    GCC >= 14.1 (soon 14.2)
+    Standard: C++23 (soon C++26)
+    MoLD >= 2.30 (linker)
+    Ninja >= 1.11.1 (builder)
+    CMake >= 3.28
+    CCache >= 4.9.1 (compiler cache)
+    DOxygen >= 1.9.8 (documentation generator)
+    vcpkg (newest)
+    bash
+    lua5.4 (package Ubuntu)
+    cppCheck >= 2.13
+    OpenSSL >= 3.0.13
+    SQLite >= 3.44
+
+Installing newer version of GCC on Ubunutu
+
+    Explained here: https://www.dedicatedcore.com/blog/install-gcc-compiler-ubuntu/ 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "WorkHorz developer",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	// Things in the feature are installed as VScode extentions within the container
+	"features": {
+		"ghcr.io/warrenbuckley/codespace-features/sqlite:1": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,28 @@
 	// Things in the feature are installed as VScode extentions within the container
 	"features": {
 		"ghcr.io/warrenbuckley/codespace-features/sqlite:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+					"ms-vscode.cpptools",
+					"ms-vscode.cmake-tools",
+					"ms-vscode.vscode-ssh",
+					"twxs.cmake"
+			],
+			"settings": {
+				"C_Cpp.default.compilerPath": "/usr/bin/gcc-14",
+				"C_Cpp.intelliSenseEngine": "default",
+				"terminal.integrated.shell.linux": "/bin/bash",
+				"terminal.integrated.profiles.windows": {
+					"WSL": {
+						"path": "C:\\Windows\\System32\\wsl.exe",
+						"args": []
+					}
+				}
+
+			}
+		}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 
 			}
 		}
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -39,7 +39,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "gcc -v",
+	"postCreateCommand": "sudo bash ./.devcontainer/startup_script.sh"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/discussion.md
+++ b/.devcontainer/discussion.md
@@ -1,0 +1,41 @@
+{
+  "name": "WorkHorz Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "context": ".",
+  "dockerFile": "Dockerfile_whz.txt",
+  "settings": {
+    "C_Cpp.default.compilerPath": "/usr/bin/gcc-14",
+    "C_Cpp.intelliSenseEngine": "Default",
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "terminal.integrated.profiles.windows": {
+      "WSL": {
+        "path": "C:\\Windows\\System32\\wsl.exe",
+        "args": []
+      }
+    },
+    "remote.WSL2.connectionMethod": "wslExeProxy"
+  },
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools",
+    "ms-vscode.vscode-ssh",
+    "twxs.cmake"
+  ],
+  "forwardPorts": [22],
+  "postCreateCommand": "cmake -B build -S . -G Ninja",
+  "remoteUser": "dockeruser",
+  "features": {
+    "ghcr.io/devcontainers/features/ccache:1": {},
+    "ghcr.io/devcontainers/features/gcc:14": {},
+    "ghcr.io/devcontainers/features/mold:2": {},
+    "ghcr.io/devcontainers/features/ninja:1": {},
+    "ghcr.io/devcontainers/features/cmake:3.28": {}
+  }
+}
+
+# TODO:[
+
+  1. Get all packages for Linux directly from APT with specified version.
+  2. Find Mac specific settings for VScode in container and add it
+  3. 
+]

--- a/.devcontainer/discussion.md
+++ b/.devcontainer/discussion.md
@@ -37,5 +37,16 @@
 
   1. Get all packages for Linux directly from APT with specified version.
   2. Find Mac specific settings for VScode in container and add it
-  3. 
+
 ]
+
+# Nov. 7th 2024
+
+## TODO
+1. A shell script that takes care of:
+  - fetch the vcpkag diretory
+  - go there and run the boot-strap.sh
+  - do a sudo git pull in that directory
+
+2. A github secret to store the dockeruser password. Make sure it doesn't need the password everytime.
+3. Set GCC as default complier - check the article sent by Patrick

--- a/.devcontainer/discussion.md
+++ b/.devcontainer/discussion.md
@@ -47,6 +47,9 @@
   - fetch the vcpkag diretory
   - go there and run the boot-strap.sh
   - do a sudo git pull in that directory
+Done :)
 
-2. A github secret to store the dockeruser password. Make sure it doesn't need the password everytime.
+~2. A github secret to store the dockeruser password. Make sure it doesn't need the password everytime.~
+I skipped this because I figured out it's not needed and I didn't encounter permission error anymore.
+
 3. Set GCC as default complier - check the article sent by Patrick

--- a/.devcontainer/startup_script.sh
+++ b/.devcontainer/startup_script.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+trap 'echo "Error occurred at line $LINENO while executing: $BASH_COMMAND"; exit 1' ERR
+
+echo "Starting the vcpkg startup script..."
+
+# Find the full path to vcpkg
+VCPKG_PATH="/usr/local/vcpkg/vcpkg"
+
+if [ -z "$VCPKG_PATH" ]; then
+  echo "Error: vcpkg is not installed or not in PATH."
+  exit 5
+fi
+echo "Found vcpkg at: $VCPKG_PATH"
+
+# Extract the directory from the path
+VCPKG_DIR=$(dirname "$VCPKG_PATH")
+
+if [ ! -d "$VCPKG_DIR" ]; then
+  echo "Error: vcpkg directory '$VCPKG_DIR' not found!"
+  exit 11
+fi
+echo "Switching to vcpkg directory: $VCPKG_DIR"
+cd "$VCPKG_DIR"
+
+if [ ! -f "./bootstrap-vcpkg.sh" ]; then
+  echo "Error: bootstrap-vcpkg.sh not found!"
+  exit 111
+fi
+
+echo "Running bootstrap-vcpkg.sh..."
+./bootstrap-vcpkg.sh
+
+if [ ! -d ".git" ]; then
+  echo "Error: Not a Git repository!"
+  exit 1111
+fi
+
+echo "Updating vcpkg repository..."
+git config --global --add safe.directory "$VCPKG_DIR"
+git pull
+
+echo "Everything in the startup script ran successfully!"


### PR DESCRIPTION
Using the latest ubuntu image from dockerhub, the first dev container is running. I tested it on `arm` based Macbook and `x76_64`linux. This worked without specifying in the `dockerfile`what is the target system.  So it should work on other linux distro or windows I assume. 

Things that still need to be done is using the specified version of `GCC`, `CMAKE`, `MOLD`etc. Because these specified version is not yet available directly from  `apt`. So it needs to be built when container is sprung up. But this increase the time of building container significantly. So a better solution or compromise should be found. 